### PR TITLE
🩹 Fix: Update README badge link and test function cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go version](https://img.shields.io/github/go-mod/go-version/brizzai/auto-mcp)](https://golang.org/doc/devel/release.html)
 [![Container Registry](https://img.shields.io/badge/container-ghcr.io-blue)](https://github.com/brizzai/auto-mcp/pkgs/container/auto-mcp)
-[![Build Status](https://img.shields.io/github/workflow/status/brizzai/auto-mcp/Go)](https://github.com/brizzai/auto-mcp/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/brizzai/auto-mcp/auto-mcp-tests.yml?branch=master)](https://github.com/brizzai/auto-mcp/actions/workflows/auto-mcp-tests.yml)
 
 Transform any OpenAPI/Swagger definition into a fully-featured **Model Context Protocol (MCP)** server – ready to run locally, inside Claude Desktop, or in the cloud.
 

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -22,7 +22,7 @@ import (
 // TestNewMCPServer_SemiE2E tests the creation and initialization of an MCP server
 // with a real OpenAPI specification but without actually serving requests.
 func TestNewMCPServer_SemiE2E(t *testing.T) {
-	// Get the current working directory 
+	// Get the current working directory
 	cwd, err := os.Getwd()
 	require.NoError(t, err, "Failed to get current working directory")
 


### PR DESCRIPTION
## Summary

This pull request includes minor fixes to a test function and the README.md file.

## Changes

- Fix: Remove trailing space in `TestNewMCPServer_SemiE2E` function (Commit 2cf2d66)
- Fix: Update Build Status badge link in `README.md` (Commit dd21ce0)

## Type of Change

<!-- Mark the appropriate option with an "x" (e.g. [x]) -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes